### PR TITLE
Added tanker page

### DIFF
--- a/Pages/Tanker.md
+++ b/Pages/Tanker.md
@@ -1,0 +1,38 @@
+# Tanker information
+
+## BLUEFOR
+
+### KC-135
+
+**FLIGHT** | **TRACK ** | **FL** | **TACAN** | **FREQUENCY** | **IFF**  | Airbase 
+ --------- | -----------| ------ | ------    | -----------   | -------- | ---- 
+**TEXACO** | AR 101     | 120    | 38X       | 150.0 MHz     | 5314     | AL DAHFRA  
+**ARCO**   | AR 201     | 200    | 39X       | 151.0 MHz     | 5311     | AL DAHFRA  
+**ARCO**   | AR 202     | 200    | 48X       | 141.0 MHz     | 5321     | AL DAHFRA  
+**ARCO**   | AR 203     | 200    | 49X       | 140.0 MHz     | 5322     | AL DAHFRA  
+
+### KC-135 MPRS
+
+**FLIGHT** | **TRACK ** | **FL** | **TACAN** | **FREQUENCY** | **IFF**  | Airbase 
+ --------- | -----------| ------ | ------    | -----------   | -------- | ---- 
+**SHELL**  | AR 301     | 240    | 40Y       | 149.0 MHz     | 5312     | AL DAHFRA  
+**SHELL**  | AR 302     | 240    | 41Y       | 148.0 MHz     | 5313     | AL DAHFRA  
+**SHELL**  | AR 303     | 240    | 42Y       | 147.0 MHz     | 5315     | AL DAHFRA  
+**SHELL**  | AR 304     | 240    | 46Y       | 146.0 MHz     | 5316     | AL DAHFRA  
+**SHELL**  | AR 305     | 240    | 37Y       | 139.0 MHz     | 5317     | AL DAHFRA  
+
+## REDFOR 
+
+### KC-135
+
+**FLIGHT** | **TRACK ** | **FL** | **TACAN** | **FREQUENCY** | **IFF**  | Airbase 
+ --------- | -----------| ------ | ------    | -----------   | -------- | ---- 
+**SHELL**  | AR 402     | 200    | 44X       | 144.0 MHz     | 5318     | ?
+**SHELL**  | AR 403     | 200    | 45X       | 143.0 MHz     | 5319     | ?
+
+### KC-135 MPRS
+
+**FLIGHT** | **TRACK ** | **FL** | **TACAN** | **FREQUENCY** | **IFF**  | Airbase 
+ --------- | -----------| ------ | ------    | -----------   | -------- | ---- 
+**SHELL**  | AR 401     | 230    | 43Y       | 145.0 MHz     | 5317     | ?
+**SHELL**  | AR 404     | 230    | 47Y       | 142.0 MHz     | 5320     | ?

--- a/Pages/Tanker.md
+++ b/Pages/Tanker.md
@@ -4,35 +4,35 @@
 
 ### KC-135
 
-**FLIGHT** | **TRACK ** | **FL** | **TACAN** | **FREQUENCY** | **IFF**  | Airbase 
- --------- | -----------| ------ | ------    | -----------   | -------- | ---- 
-**TEXACO** | AR 101     | 120    | 38X       | 150.0 MHz     | 5314     | AL DAHFRA  
-**ARCO**   | AR 201     | 200    | 39X       | 151.0 MHz     | 5311     | AL DAHFRA  
-**ARCO**   | AR 202     | 200    | 48X       | 141.0 MHz     | 5321     | AL DAHFRA  
-**ARCO**   | AR 203     | 200    | 49X       | 140.0 MHz     | 5322     | AL DAHFRA  
+**FLIGHT** | **TRACK**  | **FL** | **TACAN** | **FREQUENCY** | **IFF**  | Airbase
+ --------- | -----------| ------ | ------    | -----------   | -------- | ----
+**TEXACO** | AR 101     | 120    | 38X       | 150.0 MHz     | 5314     | AL DAHFRA
+**ARCO**   | AR 201     | 200    | 39X       | 151.0 MHz     | 5311     | AL DAHFRA
+**ARCO**   | AR 202     | 200    | 48X       | 141.0 MHz     | 5321     | AL DAHFRA
+**ARCO**   | AR 203     | 200    | 49X       | 140.0 MHz     | 5322     | AL DAHFRA
 
 ### KC-135 MPRS
 
-**FLIGHT** | **TRACK ** | **FL** | **TACAN** | **FREQUENCY** | **IFF**  | Airbase 
- --------- | -----------| ------ | ------    | -----------   | -------- | ---- 
-**SHELL**  | AR 301     | 240    | 40Y       | 149.0 MHz     | 5312     | AL DAHFRA  
-**SHELL**  | AR 302     | 240    | 41Y       | 148.0 MHz     | 5313     | AL DAHFRA  
-**SHELL**  | AR 303     | 240    | 42Y       | 147.0 MHz     | 5315     | AL DAHFRA  
-**SHELL**  | AR 304     | 240    | 46Y       | 146.0 MHz     | 5316     | AL DAHFRA  
-**SHELL**  | AR 305     | 240    | 37Y       | 139.0 MHz     | 5317     | AL DAHFRA  
+**FLIGHT** | **TRACK**  | **FL** | **TACAN** | **FREQUENCY** | **IFF**  | Airbase
+ --------- | -----------| ------ | ------    | -----------   | -------- | ----
+**SHELL**  | AR 301     | 240    | 40Y       | 149.0 MHz     | 5312     | AL DAHFRA
+**SHELL**  | AR 302     | 240    | 41Y       | 148.0 MHz     | 5313     | AL DAHFRA
+**SHELL**  | AR 303     | 240    | 42Y       | 147.0 MHz     | 5315     | AL DAHFRA
+**SHELL**  | AR 304     | 240    | 46Y       | 146.0 MHz     | 5316     | AL DAHFRA
+**SHELL**  | AR 305     | 240    | 37Y       | 139.0 MHz     | 5317     | AL DAHFRA
 
-## REDFOR 
+## REDFOR
 
 ### KC-135
 
-**FLIGHT** | **TRACK ** | **FL** | **TACAN** | **FREQUENCY** | **IFF**  | Airbase 
- --------- | -----------| ------ | ------    | -----------   | -------- | ---- 
+**FLIGHT** | **TRACK**  | **FL** | **TACAN** | **FREQUENCY** | **IFF**  | Airbase
+ --------- | -----------| ------ | ------    | -----------   | -------- | ----
 **SHELL**  | AR 402     | 200    | 44X       | 144.0 MHz     | 5318     | ?
 **SHELL**  | AR 403     | 200    | 45X       | 143.0 MHz     | 5319     | ?
 
 ### KC-135 MPRS
 
-**FLIGHT** | **TRACK ** | **FL** | **TACAN** | **FREQUENCY** | **IFF**  | Airbase 
- --------- | -----------| ------ | ------    | -----------   | -------- | ---- 
+**FLIGHT** | **TRACK**  | **FL** | **TACAN** | **FREQUENCY** | **IFF**  | Airbase
+ --------- | -----------| ------ | ------    | -----------   | -------- | ----
 **SHELL**  | AR 401     | 230    | 43Y       | 145.0 MHz     | 5317     | ?
 **SHELL**  | AR 404     | 230    | 47Y       | 142.0 MHz     | 5320     | ?

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The 132nd Virtual Wing is deployed to the Persian Gulf in a capacity to provide 
 * [Radio frequencies](/Pages/Presets.md)
 * [Standing SPINS](/ATRM_Brief/Pages/SPINS.html)
 * [Flight information](/ATRM_Brief/Pages/Flights.html)
+* [Tanker information](/ATRM_Brief/Pages/Tanker.html)
 * [FLIP Gulf Region](https://www.dropbox.com/s/sp91zf63rx0esao/FLIP_GULFR2_EC1.pdf?dl=0)
 
 


### PR DESCRIPTION
All information stem from the lua scripts of the ATRM mission file, and the ME. Currently, there are no tanker information at all on ATRM_Brief.